### PR TITLE
Apply function signatures directly to the til files

### DIFF
--- a/plugin/apply_to_til.py
+++ b/plugin/apply_to_til.py
@@ -1,4 +1,8 @@
-import ida
+try:
+    import ida
+except ImportError:
+    print("This script requires the ida module to be installed. Please consult the IDADIR/idalib/README.txt file for instructions on how to install it.")
+    exit()
 import idaapi
 import os
 

--- a/plugin/apply_to_til.py
+++ b/plugin/apply_to_til.py
@@ -29,16 +29,16 @@ config = argparse.ArgumentParser(
 )
 
 config.add_argument(
-    "--binary",
+    "--platform",
     type=str,
-    help="Binary type",
+    help="Platform type",
     choices=default_til_masks.keys(),
     default="windows",
 )
 config.add_argument(
     "--tilmask",
     type=str,
-    help=f"Til mask (defaults to mssdk*.til or gnulnx*.til depending on --binary)",
+    help=f"Til mask (defaults to mssdk*.til or gnulnx*.til depending on --platform)",
     default=None,
 )
 config.add_argument(
@@ -67,7 +67,7 @@ config.add_argument(
     help="Overwrite existing ida files (will backup the original files), use with caution. You will likely need an administrator / root access to overwrite the files.",
 )
 config.add_argument("--loglevel", type=str, help="Log level", default="INFO")
-config.epilog = "Example: python apply_to_til.py --binary windows"
+config.epilog = "Example: python apply_to_til.py --platform windows"
 
 
 def type_for_name(til: idaapi.til_t, s: str) -> idaapi.tinfo_t:
@@ -139,7 +139,7 @@ class ida_opener:
 
 def process_til(
     til_file: Path,
-    binary_type: str,
+    platform_type: str,
     out_file: Path,
     idb: Path,
     func_map: FunctionMap,
@@ -166,7 +166,7 @@ def process_til(
         for name in func_map:
             change_type(til, name, name, BOOL, func_map)
             # Add A/W versions for windows
-            if binary_type == "windows":
+            if platform_type == "windows":
                 change_type(til, name, name + "A", BOOL, func_map)
                 change_type(til, name, name + "W", BOOL, func_map)
 
@@ -187,9 +187,9 @@ def main():
     args = config.parse_args()
     logging.getLogger().setLevel(args.loglevel)
     tildir = Path(args.tildir)
-    tilmask = args.tilmask or default_til_masks[args.binary]
+    tilmask = args.tilmask or default_til_masks[args.platform]
 
-    function_map = FunctionMap(args.funcmap / args.binary)
+    function_map = FunctionMap(args.funcmap / args.platform)
 
     changed_files: "list[tuple[Path, Path]]" = []
 
@@ -197,7 +197,7 @@ def main():
         new_til = Path(args.outdir) / old_til.relative_to(tildir)
         ok = process_til(
             old_til,
-            args.binary,
+            args.platform,
             new_til,
             Path(args.idb),
             function_map,

--- a/plugin/apply_to_til.py
+++ b/plugin/apply_to_til.py
@@ -22,7 +22,7 @@ default_til_masks = {
 }
 
 default_til_dir = idaapi.idadir("til")
-default_idb = "a.i64"
+default_idb = "../demo/demo"
 
 config = argparse.ArgumentParser(
     description="Apply fixes to function signatures directly to the til files"

--- a/plugin/apply_to_til.py
+++ b/plugin/apply_to_til.py
@@ -29,23 +29,23 @@ config = argparse.ArgumentParser(
 )
 
 config.add_argument(
-    "--tildir",
-    type=str,
-    help="Path to the IDA til directory",
-    default=default_til_dir,
-)
-config.add_argument(
-    "--tilmask",
-    type=str,
-    help=f"Til mask (mssdk*.til or gnulnx*.til depending on --binary)",
-    default=None,
-)
-config.add_argument(
     "--binary",
     type=str,
     help="Binary type",
     choices=default_til_masks.keys(),
     default="windows",
+)
+config.add_argument(
+    "--tilmask",
+    type=str,
+    help=f"Til mask (defaults to mssdk*.til or gnulnx*.til depending on --binary)",
+    default=None,
+)
+config.add_argument(
+    "--tildir",
+    type=str,
+    help="Path to the IDA til directory (defaults to the IDA til directory)",
+    default=default_til_dir,
 )
 config.add_argument("--outdir", type=str, help="Output directory", default="out")
 config.add_argument(
@@ -55,17 +55,18 @@ config.add_argument(
     default=default_idb,
 )
 config.add_argument(
+    "--funcmap",
+    type=Path,
+    help="Path to the function map directory. Defaults to the data folder next to the script.",
+    default=Path(__file__).parent / "data",
+)
+config.add_argument(
     "--overwrite",
     action="store_true",
     default=False,
     help="Overwrite existing ida files (will backup the original files), use with caution. You will likely need an administrator / root access to overwrite the files.",
 )
-config.add_argument(
-    "--funcmap",
-    type=Path,
-    help="Path to the function map directory",
-    default=Path(__file__).parent / "data",
-)
+config.add_argument("--loglevel", type=str, help="Log level", default="INFO")
 config.epilog = "Example: python apply_to_til.py --binary windows"
 
 
@@ -184,6 +185,7 @@ def process_til(
 
 def main():
     args = config.parse_args()
+    logging.getLogger().setLevel(args.loglevel)
     tildir = Path(args.tildir)
     tilmask = args.tilmask or default_til_masks[args.binary]
 

--- a/plugin/apply_to_til.py
+++ b/plugin/apply_to_til.py
@@ -1,0 +1,94 @@
+import ida
+import idaapi
+import os
+
+from auto_enum import get_function_map, get_or_add_enum
+
+
+def type_for_name(til:idaapi.til_t, s:str)->idaapi.tinfo_t:
+    named_type = idaapi.get_named_type(til, s, 0)
+    if named_type is None:
+        return None
+    (code, type_str, fields_str, cmt, field_cmts, sclass, value) = named_type
+    #print(f"{code=}, {type_str=}, {fields_str=}, {cmt=}, {field_cmts=}, {sclass=}, {value=}")
+    t = idaapi.tinfo_t()
+    # deserialize(self, til, ptype, pfields=None, pfldcmts=None, cmt=None) -> bool
+    assert t.deserialize(til, type_str, fields_str)#, field_cmts, cmt)
+    return t
+
+
+def change_type(til:idaapi.til_t, name:str, ida_name:str, BOOL)->bool:
+    ti = type_for_name(til, ida_name)
+
+    if not ti:
+        return
+
+    funcdata = idaapi.func_type_data_t()
+    ok = ti.get_func_details(funcdata)
+    assert ok, "Failed to get function details"
+
+    if not funcdata:
+            return
+    
+    
+    changed = False
+
+    for arg in funcdata:
+        if arg.type.is_ptr():
+            continue
+        type_name = arg.type.get_type_name()
+        if type_name is not None and type_name.lower() in ["bool"]:
+            arg.type = BOOL
+            changed = True
+        elif arg.type.is_integral() and not arg.type.is_enum():
+            func = func_map[name]
+            matching_arg = next((a for a in func.arguments if a.name == arg.name), None)
+            if matching_arg and matching_arg.enum is not None:
+                enum_name = get_or_add_enum(func_map, matching_arg.enum, til)
+                enum_type = idaapi.tinfo_t()
+                enum_type.get_named_type(til, enum_name)
+                arg.type = enum_type
+                changed = True
+        
+    if changed:
+        ti = idaapi.tinfo_t()
+        ti.create_func(funcdata)
+    
+        err = ti.set_symbol_type(til, ida_name, idaapi.NTF_REPLACE | idaapi.NTF_COPY)
+
+        if err:
+            err_str = idaapi.tinfo_errstr(err)
+            print(f"Error setting symbol type for {name}: {err_str}")
+
+idadir =  "/Applications/IDA Professional 9.0.app/Contents/MacOS/til/pc/"
+
+tils = os.listdir(idadir)
+
+for til_name in tils:
+    if "mssdk" not in til_name:
+        continue
+
+    ida.open_database(r"a.i64", False)
+
+    til = idaapi.load_til("pc/" + til_name)
+    func_map = get_function_map("windows")
+
+    BOOL = idaapi.tinfo_t()
+    if not BOOL.get_named_type(til, "MACRO_BOOL"):
+        ida.close_database(False)
+        continue
+
+    print(f"Processing {til_name}")
+
+    for name in func_map:
+        change_type(til, name, name, BOOL)
+        change_type(til, name, name+"A", BOOL)
+        change_type(til, name, name+"W", BOOL)
+
+    idaapi.compact_til(til)
+    if not os.path.exists("pc"):
+        os.mkdir("pc")
+    idaapi.store_til(til, "pc", til_name)
+
+    del BOOL
+    ida.close_database(False)

--- a/plugin/auto_enum.py
+++ b/plugin/auto_enum.py
@@ -353,11 +353,6 @@ def PLUGIN_ENTRY():
     return AutoEnumPlugin()
 
 
-def get_function_map(binary_type = "windows"):
-    thisdir = os.path.dirname(__file__)
-    return FunctionMap(os.path.join(thisdir, "data", binary_type))
-
-
 def main():
     handle = ida_hexrays.open_pseudocode(idc.here(), 0)
     library_calls = {}

--- a/plugin/auto_enum.py
+++ b/plugin/auto_enum.py
@@ -172,6 +172,12 @@ class FunctionMap:
         self.data_dir = data_dir
         self.enums = json.loads(open(f"{self.data_dir}/enums.json").read())
 
+    def __iter__(self):
+        for funcname in os.listdir(f"{self.data_dir}/functions"):
+            if not funcname.endswith(".json"):
+                continue
+            yield funcname.split(".")[0]
+
     @functools.lru_cache()
     def __contains__(self, funcname: str):
         return os.path.exists(f"{self.data_dir}/functions/{funcname}.json")
@@ -271,7 +277,7 @@ def get_funcinfo(funcptr_addr):
 
 
 @functools.lru_cache()
-def get_or_add_enum(funcmap: FunctionMap, enum_id: str):
+def get_or_add_enum(funcmap: FunctionMap, enum_id: str, til: idaapi.til_t=None):
     enum_name = f"ENUM_{enum_id}"
     ida_enum_id = idc.get_enum(enum_name)
     if ida_enum_id == idaapi.BADADDR:
@@ -285,6 +291,10 @@ def get_or_add_enum(funcmap: FunctionMap, enum_id: str):
                 res = idc.add_enum_member(ida_enum_id, f"{k}_{append}", v, -1)
                 append += 1
         ida_typeinf.end_type_updating(ida_typeinf.UTP_ENUM)
+        if til:
+            tif = idaapi.tinfo_t()
+            tif.get_type_by_tid(ida_enum_id)
+            tif.set_named_type(til, enum_name, idaapi.NTF_REPLACE | idaapi.NTF_COPY)
         return enum_name
     return enum_name
 
@@ -341,6 +351,11 @@ class AutoEnumPlugin(idaapi.plugin_t):
 
 def PLUGIN_ENTRY():
     return AutoEnumPlugin()
+
+
+def get_function_map(binary_type = "windows"):
+    thisdir = os.path.dirname(__file__)
+    return FunctionMap(os.path.join(thisdir, "data", binary_type))
 
 
 def main():


### PR DESCRIPTION
This PR adds `plugin/apply_to_til.py` script that applies the knowledge from `data` folder directly to the til files that ida uses.

This renders the rest of the project obsolete, as the til files are the source of truth for the function signatures.

To apply the changes:
1) put a dummy `a.i64` file next to the script
2) run the script
3) copy the `pc` folder to the `til` folder in the IDA installation directory replacing the existing files (make a backup first)